### PR TITLE
Use secure URL

### DIFF
--- a/adblock
+++ b/adblock
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Block ad serving and tracking system-wide even before a request is issued to them.
 
-SOURCE='http://someonewhocares.org/hosts/zero/hosts'
+SOURCE='https://someonewhocares.org/hosts/zero/hosts'
 BACKUP='https://raw.github.com/MattiSG/adblock/master/hosts.default'
 TARGET='/etc/hosts'
 DOWNLOADED='/etc/hosts.blocklist'


### PR DESCRIPTION
Using curl with the insecure URL (http://) now produces a 302 error with this body:

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://someonewhocares.org/hosts/zero/hosts">here</a>.</p>
</body></html>
```

Using the secure URL ensures this HTML is not written to the hosts file. 